### PR TITLE
Remove live server extension

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "liveServer.settings.port": 5501
-}


### PR DESCRIPTION
In this commit, the live server port was removed.